### PR TITLE
cf app-placement: WARN: Unresolved specs during Gem::Specification.reset

### DIFF
--- a/tools-cf-plugin.gemspec
+++ b/tools-cf-plugin.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "cfoundry"
   s.add_runtime_dependency "nats"
   s.add_runtime_dependency "net-ssh"
+  s.add_runtime_dependency "net-ssh-gateway"
   s.add_runtime_dependency "pry"
 
   s.add_development_dependency "rake", ">= 0.9"


### PR DESCRIPTION
```
~  gem install tools-cf-plugin
Fetching: tools-cf-plugin-3.0.0.gem (100%)
Successfully installed tools-cf-plugin-3.0.0
Installing ri documentation for tools-cf-plugin-3.0.0
1 gem installed
➜  ~  cf app-placement
WARN: Unresolved specs during Gem::Specification.reset:
      atomic (>= 0)
      net-ssh (>= 0)
      daemons (>= 1.1.5)
      thin (>= 1.4.1)
WARN: Clearing out unresolved specs.
```
