### PR TITLE
[dea-ads] show 'Available Disk'

### DIFF
--- a/lib/tools-cf-plugin/dea-ads.rb
+++ b/lib/tools-cf-plugin/dea-ads.rb
@@ -42,7 +42,7 @@ module CFTools
     end
 
     def render_table
-      rows = 
+      rows =
         advertisements.sort.collect do |id, (attrs, prev)|
           idx, _ = id.split("-", 2)
 
@@ -51,11 +51,14 @@ module CFTools
             diff(attrs, prev) { |x| x["app_id_to_count"].values.inject(0, &:+) },
             diff(attrs, prev, :pretty_memory, :pretty_memory_diff) do |x|
               x["available_memory"]
+            end,
+            diff(attrs, prev, :pretty_memory, :pretty_memory_diff) do |x|
+              x["available_disk"]
             end
           ]
         end
 
-      table(["dea", "stacks", "droplets", "available memory"], rows)
+      table(["dea", "stacks", "droplets", "available memory", "available disk"], rows)
     end
 
     def diff(curr, prev, pretty = nil, pretty_diff = :signed)

--- a/spec/dea-ads_spec.rb
+++ b/spec/dea-ads_spec.rb
@@ -54,6 +54,7 @@ describe CFTools::DEAAds do
     "id3": 3
   },
   "available_memory": 1256,
+  "available_disk": 12560,
   "stacks": [
     "lucid64",
     "lucid86"
@@ -77,6 +78,7 @@ PAYLOAD
 {
   "app_id_to_count": {},
   "available_memory": 1256,
+  "available_disk": 12560,
   "stacks": [
     "lucid64"
   ],
@@ -105,6 +107,7 @@ PAYLOAD
     "id4": 1
   },
   "available_memory": 1024,
+  "available_disk": 10240,
   "stacks": [
     "lucid64"
   ],
@@ -120,7 +123,7 @@ PAYLOAD
 
         it "keeps the other entry in the table" do
           cf %W[dea-ads]
-          expect(output).to say(/^2\s+lucid64, lucid86\s+6\s+1\.2G$/)
+          expect(output).to say(/^2\s+lucid64, lucid86\s+6\s+1\.2G\s+12.3G$/)
         end
 
         it "sorts the rows by DEA index" do
@@ -138,6 +141,7 @@ PAYLOAD
     "id3": 3
   },
   "available_memory": 1000,
+  "available_disk": 10000,
   "stacks": [
     "lucid64"
   ],
@@ -153,7 +157,7 @@ PAYLOAD
 
         it "shows the difference from the last advertisement" do
           cf %W[dea-ads]
-          expect(output).to say(/^2\s+lucid64\s+5 \(-1\)\s+1000\.0M \(-256\.0M\)$/)
+          expect(output).to say(/^2\s+lucid64\s+5 \(-1\)\s+1000\.0M \(-256\.0M\)\s+9\.8G \(-2\.5G\)$/)
         end
       end
     end


### PR DESCRIPTION
Update: Perhaps merge #13 first to ensure tests pass nicely

CI is currently failing, but the dea-ads_spec.rb is passing locally:

```
Finished in 0.06357 seconds (files took 1.59 seconds to load)
12 examples, 0 failures
```

Example of it in action:

![_mosh__ubuntu_ip-10-15-212-82____repos_tools-cf-plugin__mosh-client__17845](https://cloud.githubusercontent.com/assets/108/3788539/27a5ebc2-1a6b-11e4-9498-304244522605.png)
